### PR TITLE
Improve AVI Detector

### DIFF
--- a/src/Detector/AviDetector.php
+++ b/src/Detector/AviDetector.php
@@ -23,6 +23,15 @@ final class AviDetector implements VideoDetectorInterface
     {
         $bytes = (string)$file->fread(4);
 
-        return $bytes === 'RIFF' ? new VideoType(VideoFormat::AVI, VideoMimeType::VIDEO_AVI) : null;
+        // Skip 4 bytes
+        $file->fread(4);
+
+        // Fetch AVI identified data
+        $identifiedData = (string)$file->fread(3);
+
+        return $bytes === 'RIFF' && $identifiedData === 'AVI' ? new VideoType(
+            VideoFormat::AVI,
+            VideoMimeType::VIDEO_AVI
+        ) : null;
     }
 }


### PR DESCRIPTION
According to original `AVI` detector approach, it's not good enough.

According to the  [reference](http://fileformats.archiveteam.org/wiki/AVI), It should check whether the identified data is `AVI`.