### PR TITLE
Update PHP requirement and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
 
     steps:
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, pdo, pdo_mysql, intl, zip

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     "homepage": "https://github.com/selective-php/video-type",
     "license": "MIT",
     "require": {
-        "php": "^7.2"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",
-        "overtrue/phplint": "^1.1",
-        "phpunit/phpunit": "^8 || ^9",
+        "overtrue/phplint": "^2.3",
+        "phpunit/phpunit": "^9",
         "phpstan/phpstan": "^1",
-        "squizlabs/php_codesniffer": "^3.4"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "scripts": {
         "check": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          colors="true"
          backupGlobals="false"
          backupStaticAttributes="false"
-         timeoutForLargeTests="900">
+         timeoutForLargeTests="900"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
     <testsuites>
         <testsuite name="Tests">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
+    <coverage processUncoveredFiles="false">
+        <include>
             <directory suffix=".php">src</directory>
-            <exclude>
-                <directory>vendor</directory>
-                <directory>build</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>vendor</directory>
+            <directory>build</directory>
+        </exclude>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
# Changed log

- Update PHP version requirements and related dependencies.
- Adding the `php8.0+` version supports.
- Update the `phpunit.xml` file to be compatible with the latest PHPUnit version.
- These changes are referred by the [audio-type composer.json file](https://github.com/selective-php/audio-type/blob/master/composer.json).